### PR TITLE
Add PWA prototype for JOGO

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1,0 +1,23 @@
+{
+  "login": "Login",
+  "signup": "Sign Up",
+  "switch_to_signup": "No account? Sign up",
+  "switch_to_login": "Already have an account? Login",
+  "dashboard": "Matches",
+  "map": "Map",
+  "leagues": "Leagues",
+  "profile": "Profile",
+  "create_match": "Create Match",
+  "match_title": "Title",
+  "match_place": "Place",
+  "match_when": "When",
+  "create_league": "Create League",
+  "name": "Name",
+  "email": "Email",
+  "save": "Save",
+  "logout": "Logout",
+  "reserve": "Reserve",
+  "chat": "Chat",
+  "send": "Send",
+  "language": "Language"
+}

--- a/i18n/fr.json
+++ b/i18n/fr.json
@@ -1,0 +1,23 @@
+{
+  "login": "Connexion",
+  "signup": "Inscription",
+  "switch_to_signup": "Pas de compte? Inscrivez-vous",
+  "switch_to_login": "Déjà inscrit? Connectez-vous",
+  "dashboard": "Matchs",
+  "map": "Carte",
+  "leagues": "Ligues",
+  "profile": "Profil",
+  "create_match": "Créer un match",
+  "match_title": "Titre",
+  "match_place": "Lieu",
+  "match_when": "Date",
+  "create_league": "Créer une ligue",
+  "name": "Nom",
+  "email": "Email",
+  "save": "Enregistrer",
+  "logout": "Déconnexion",
+  "reserve": "Réserver",
+  "chat": "Chat",
+  "send": "Envoyer",
+  "language": "Langue"
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>JOGO</title>
+  <link rel="manifest" href="manifest.json">
+  <style>
+    :root {
+      --bg: #f5f5f5;
+      --primary: #2b7a78;
+      --secondary: #17252a;
+      --accent: #def2f1;
+      --text: #222;
+      font-family: Arial, sans-serif;
+    }
+    body { margin:0; background:var(--bg); color:var(--text); }
+    header { background:var(--primary); color:#fff; padding:1rem; display:flex; justify-content:space-between; align-items:center; }
+    nav button { margin-right:0.5rem; }
+    #auth, #app { padding:1rem; }
+    .hidden { display:none; }
+    section { margin-bottom:1rem; }
+    ul { list-style:none; padding:0; }
+    li { background:#fff; margin-bottom:0.5rem; padding:0.5rem; border-radius:4px; }
+    input, button, select { padding:0.5rem; margin:0.2rem 0; }
+    .modal { position:fixed; top:0; left:0; right:0; bottom:0; background:rgba(0,0,0,0.5); display:flex; justify-content:center; align-items:center; }
+    .modal-content { background:#fff; padding:1rem; border-radius:4px; max-width:90%; }
+    #map { height:300px; margin-bottom:1rem; }
+  </style>
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
+</head>
+<body>
+  <header>
+    <h1>JOGO</h1>
+    <div id="lang-switch"></div>
+  </header>
+  <div id="auth">
+    <h2 id="auth-title"></h2>
+    <input id="auth-name" placeholder="Name" class="hidden">
+    <input id="auth-email" placeholder="Email">
+    <input id="auth-pass" type="password" placeholder="Password">
+    <button id="auth-action"></button>
+    <p id="auth-toggle"></p>
+  </div>
+
+  <div id="app" class="hidden">
+    <nav>
+      <button data-page="dashboard"></button>
+      <button data-page="map"></button>
+      <button data-page="leagues"></button>
+      <button data-page="profile"></button>
+    </nav>
+    <section id="dashboard" class="page"></section>
+    <section id="map-page" class="page hidden">
+      <div id="map"></div>
+    </section>
+    <section id="leagues" class="page hidden"></section>
+    <section id="profile" class="page hidden"></section>
+  </div>
+
+  <div id="modal" class="hidden"></div>
+
+  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+  <script type="module" src="js/app.js"></script>
+</body>
+</html>

--- a/js/app.js
+++ b/js/app.js
@@ -1,0 +1,33 @@
+import { qs, qsa, on } from './utils.js';
+import { initAuth, getCurrentUser } from './auth.js';
+import { renderDashboard, getMatchById } from './dashboard.js';
+import { renderMap } from './map.js';
+import { renderLeagues } from './leagues.js';
+import { renderProfile } from './profile.js';
+import { openChat } from './chat.js';
+import { openReserve } from './reservation.js';
+import { registerSW } from './pwa.js';
+import './i18n.js';
+
+window.JOGO = { openChat, openReserve };
+
+function showPage(id) {
+  qsa('.page').forEach(p => p.classList.add('hidden'));
+  qs('#'+id).classList.remove('hidden');
+  if (id==='map-page') renderMap();
+  if (id==='dashboard') renderDashboard(openChat, openReserve);
+  if (id==='leagues') renderLeagues();
+  if (id==='profile') renderProfile(()=>location.reload());
+}
+
+function initApp() {
+  qs('#auth').classList.add('hidden');
+  qs('#app').classList.remove('hidden');
+  renderDashboard(openChat, openReserve);
+  qsa('nav button').forEach(btn => on(btn,'click',()=>showPage(btn.dataset.page)));
+  registerSW();
+}
+
+const user = getCurrentUser();
+if (user) initApp();
+else initAuth(initApp);

--- a/js/auth.js
+++ b/js/auth.js
@@ -1,0 +1,63 @@
+import { qs, on } from './utils.js';
+import { t } from './i18n.js';
+
+function getUsers() {
+  return JSON.parse(localStorage.getItem('users') || '[]');
+}
+function saveUsers(users) {
+  localStorage.setItem('users', JSON.stringify(users));
+}
+
+export function initAuth(onAuth) {
+  let signup = false;
+  const title = qs('#auth-title');
+  const action = qs('#auth-action');
+  const toggle = qs('#auth-toggle');
+  const nameInput = qs('#auth-name');
+
+  function render() {
+    if (signup) {
+      title.textContent = t('signup');
+      action.textContent = t('signup');
+      toggle.textContent = t('switch_to_login');
+      nameInput.classList.remove('hidden');
+    } else {
+      title.textContent = t('login');
+      action.textContent = t('login');
+      toggle.textContent = t('switch_to_signup');
+      nameInput.classList.add('hidden');
+    }
+  }
+
+  on(action, 'click', () => {
+    const email = qs('#auth-email').value;
+    const pass = qs('#auth-pass').value;
+    const name = nameInput.value;
+    if (signup) {
+      const users = getUsers();
+      if (users.find(u => u.email === email)) return alert('Exists');
+      users.push({ email, pass, name });
+      saveUsers(users);
+      signup = false;
+      render();
+    } else {
+      const user = getUsers().find(u => u.email === email && u.pass === pass);
+      if (user) {
+        sessionStorage.setItem('user', JSON.stringify(user));
+        onAuth(user);
+      } else alert('Invalid');
+    }
+  });
+
+  on(toggle, 'click', () => { signup = !signup; render(); });
+  render();
+}
+
+export function getCurrentUser() {
+  const u = sessionStorage.getItem('user');
+  return u ? JSON.parse(u) : null;
+}
+
+export function logout() {
+  sessionStorage.removeItem('user');
+}

--- a/js/chat.js
+++ b/js/chat.js
@@ -1,0 +1,22 @@
+import { qs, createEl, on } from './utils.js';
+import { t } from './i18n.js';
+
+function getChats() {
+  return JSON.parse(localStorage.getItem('chats') || '{}');
+}
+function saveChats(c) { localStorage.setItem('chats', JSON.stringify(c)); }
+
+export function openChat(matchId) {
+  const chats = getChats();
+  const msgs = chats[matchId] || [];
+  const modal = qs('#modal');
+  modal.innerHTML = `<div class="modal"><div class="modal-content"><h3>${t('chat')}</h3><div id="chat-msgs" style="max-height:200px;overflow:auto"></div><input id="chat-input"><button id="chat-send">${t('send')}</button></div></div>`;
+  modal.classList.remove('hidden');
+  const list = qs('#chat-msgs');
+  list.innerHTML = msgs.map(m=>`<div>${m}</div>`).join('');
+  on(qs('#chat-send'),'click',()=>{
+    const text = qs('#chat-input').value;
+    if (text) { msgs.push(text); chats[matchId]=msgs; saveChats(chats); list.innerHTML += `<div>${text}</div>`; qs('#chat-input').value=''; }
+  });
+  on(modal,'click',e=>{ if(e.target===modal) modal.classList.add('hidden'); });
+}

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -1,0 +1,43 @@
+import { qs, createEl, on } from './utils.js';
+import { t } from './i18n.js';
+
+function getMatches() {
+  return JSON.parse(localStorage.getItem('matches') || '[]');
+}
+function saveMatches(ms) {
+  localStorage.setItem('matches', JSON.stringify(ms));
+}
+
+export function renderDashboard(openChat, openReserve) {
+  const container = qs('#dashboard');
+  container.innerHTML = `<h2>${t('dashboard')}</h2><button id="new-match">${t('create_match')}</button><ul id="match-list"></ul>`;
+  const list = qs('#match-list');
+  const matches = getMatches();
+  matches.forEach(m => list.append(matchItem(m)));
+  on(qs('#new-match'), 'click', () => {
+    const title = prompt(t('match_title'));
+    const place = prompt(t('match_place'));
+    const when = prompt(t('match_when'));
+    if (title) {
+      const m = { id: Date.now(), title, place, when, coords:[48.85,2.35] };
+      matches.push(m);
+      saveMatches(matches);
+      list.append(matchItem(m));
+    }
+  });
+}
+
+function matchItem(m) {
+  const li = createEl('li');
+  li.textContent = `${m.title} - ${m.place} - ${m.when}`;
+  const chatBtn = createEl('button',{textContent:t('chat')});
+  const resBtn = createEl('button',{textContent:t('reserve')});
+  li.append(' ', chatBtn, ' ', resBtn);
+  on(chatBtn,'click',()=>window.JOGO.openChat(m.id));
+  on(resBtn,'click',()=>window.JOGO.openReserve(m.id));
+  return li;
+}
+
+export function getMatchById(id) {
+  return getMatches().find(m => m.id===id);
+}

--- a/js/i18n.js
+++ b/js/i18n.js
@@ -1,0 +1,33 @@
+import { qs } from './utils.js';
+
+const LOCALES = ['en', 'fr'];
+let current = localStorage.getItem('lang') || 'en';
+let dict = {};
+
+export const t = key => dict[key] || key;
+
+export async function load(lang) {
+  if (!LOCALES.includes(lang)) lang = 'en';
+  dict = await fetch(`i18n/${lang}.json`).then(r => r.json());
+  current = lang;
+  localStorage.setItem('lang', lang);
+  renderTexts();
+}
+
+function renderTexts() {
+  qs('#auth-action').textContent = t('login');
+  qs('#auth-toggle').textContent = t('switch_to_signup');
+  qs('nav button[data-page="dashboard"]').textContent = t('dashboard');
+  qs('nav button[data-page="map"]').textContent = t('map');
+  qs('nav button[data-page="leagues"]').textContent = t('leagues');
+  qs('nav button[data-page="profile"]').textContent = t('profile');
+  qs('#lang-switch').innerHTML = `${t('language')}: <select id="lang-select">${LOCALES.map(l=>`<option value="${l}" ${l===current?'selected':''}>${l.toUpperCase()}</option>`).join('')}</select>`;
+  qs('#auth-title').textContent = t('login');
+}
+
+onload = () => {
+  load(current);
+  document.addEventListener('change', e => {
+    if (e.target.id === 'lang-select') load(e.target.value);
+  });
+};

--- a/js/leagues.js
+++ b/js/leagues.js
@@ -1,0 +1,21 @@
+import { qs, createEl, on } from './utils.js';
+import { t } from './i18n.js';
+
+function getLeagues() {
+  return JSON.parse(localStorage.getItem('leagues') || '[]');
+}
+function saveLeagues(ls) {
+  localStorage.setItem('leagues', JSON.stringify(ls));
+}
+
+export function renderLeagues() {
+  const container = qs('#leagues');
+  container.innerHTML = `<h2>${t('leagues')}</h2><button id="new-league">${t('create_league')}</button><ul id="league-list"></ul>`;
+  const list = qs('#league-list');
+  const leagues = getLeagues();
+  leagues.forEach(l => list.append(createEl('li',{textContent:l.name})));
+  on(qs('#new-league'),'click',()=>{
+    const name = prompt(t('name'));
+    if (name) { const l = {id:Date.now(), name}; leagues.push(l); saveLeagues(leagues); list.append(createEl('li',{textContent:name})); }
+  });
+}

--- a/js/map.js
+++ b/js/map.js
@@ -1,0 +1,16 @@
+import { qs } from './utils.js';
+import { getMatchById } from './dashboard.js';
+let map;
+export function renderMap() {
+  if (!map) {
+    map = L.map('map').setView([48.85, 2.35], 13);
+    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+      maxZoom: 19
+    }).addTo(map);
+  }
+  L.layerGroup().addTo(map);
+  const matches = JSON.parse(localStorage.getItem('matches') || '[]');
+  matches.forEach(m => {
+    L.marker(m.coords).addTo(map).bindPopup(m.title);
+  });
+}

--- a/js/profile.js
+++ b/js/profile.js
@@ -1,0 +1,20 @@
+import { qs, on } from './utils.js';
+import { t } from './i18n.js';
+import { getCurrentUser, logout } from './auth.js';
+
+export function renderProfile(onLogout) {
+  const user = getCurrentUser();
+  const container = qs('#profile');
+  container.innerHTML = `<h2>${t('profile')}</h2>
+    <label>${t('name')} <input id="prof-name" value="${user.name}"></label>
+    <label>${t('email')} <input id="prof-email" value="${user.email}"></label>
+    <button id="save-prof">${t('save')}</button>
+    <button id="logout">${t('logout')}</button>`;
+  on(qs('#save-prof'),'click',()=>{
+    user.name = qs('#prof-name').value;
+    user.email = qs('#prof-email').value;
+    sessionStorage.setItem('user', JSON.stringify(user));
+    alert('saved');
+  });
+  on(qs('#logout'),'click',()=>{ logout(); onLogout(); });
+}

--- a/js/pwa.js
+++ b/js/pwa.js
@@ -1,0 +1,5 @@
+export function registerSW() {
+  if ('serviceWorker' in navigator) {
+    navigator.serviceWorker.register('service-worker.js');
+  }
+}

--- a/js/reservation.js
+++ b/js/reservation.js
@@ -1,0 +1,16 @@
+import { qs, on } from './utils.js';
+import { t } from './i18n.js';
+
+function getRes() { return JSON.parse(localStorage.getItem('reservations')||'{}'); }
+function saveRes(r) { localStorage.setItem('reservations', JSON.stringify(r)); }
+
+export function openReserve(matchId) {
+  const res = getRes();
+  const modal = qs('#modal');
+  modal.innerHTML = `<div class="modal"><div class="modal-content"><p>${t('reserve')}?</p><button id="ok-res">OK</button></div></div>`;
+  modal.classList.remove('hidden');
+  on(qs('#ok-res'),'click',()=>{
+    res[matchId] = true; saveRes(res); modal.classList.add('hidden');
+  });
+  on(modal,'click',e=>{ if(e.target===modal) modal.classList.add('hidden'); });
+}

--- a/js/utils.js
+++ b/js/utils.js
@@ -1,0 +1,8 @@
+export const qs = s => document.querySelector(s);
+export const qsa = s => Array.from(document.querySelectorAll(s));
+export const on = (el, ev, fn) => el.addEventListener(ev, fn);
+export const createEl = (tag, attrs = {}) => {
+  const el = document.createElement(tag);
+  Object.entries(attrs).forEach(([k,v]) => el[k] = v);
+  return el;
+};

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,19 @@
+{
+  "name": "JOGO",
+  "short_name": "JOGO",
+  "start_url": "./index.html",
+  "display": "standalone",
+  "scope": "./",
+  "icons": [
+    {
+      "src": "icon-192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "icon-512.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ]
+}

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,0 +1,26 @@
+const CACHE = 'jogo-cache-v1';
+const ASSETS = [
+  './index.html',
+  './manifest.json',
+  './js/app.js',
+  './js/auth.js',
+  './js/dashboard.js',
+  './js/map.js',
+  './js/leagues.js',
+  './js/profile.js',
+  './js/chat.js',
+  './js/reservation.js',
+  './js/i18n.js',
+  './js/pwa.js',
+  './js/utils.js',
+  './i18n/en.json',
+  './i18n/fr.json',
+  'https://unpkg.com/leaflet@1.9.4/dist/leaflet.js',
+  'https://unpkg.com/leaflet@1.9.4/dist/leaflet.css'
+];
+self.addEventListener('install', e => {
+  e.waitUntil(caches.open(CACHE).then(c => c.addAll(ASSETS)));
+});
+self.addEventListener('fetch', e => {
+  e.respondWith(caches.match(e.request).then(r => r || fetch(e.request)));
+});


### PR DESCRIPTION
## Summary
- create HTML layout with embedded CSS and Leaflet map
- add service worker and manifest for offline use
- implement JS modules for auth, dashboard, map, leagues, profile, chat, reservation, utils, i18n and PWA registration
- include FR and EN translations

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6857b06b4468832b970e867fdc7d1e03